### PR TITLE
Make Emacs look and feel more like an IDE for C#

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ These are my personal config files for [Doom Emacs](https://github.com/hlissner/
 
 ## Prerequisites
 
-In addition to the Doom Emacs requirements, this config uses the [Iosevka SS04 font](https://github.com/be5invis/Iosevka).
+In addition to the Doom Emacs requirements, this config uses the [JetBrains Mono font](https://www.jetbrains.com/lp/mono).

--- a/config.el
+++ b/config.el
@@ -13,3 +13,4 @@
 (use-package! editing)
 (use-package! lisps)
 (use-package! writing)
+(use-package! ide)

--- a/functions/cycle-theme.el
+++ b/functions/cycle-theme.el
@@ -1,8 +1,7 @@
 ;;; functions/cycle-theme.el -*- lexical-binding: t; -*-
 
 (defvar jsvm/active-themes '(doom-nord
-                             doom-nord-light
-                             doom-material)
+                             doom-plain)
   "Active themes to cycle through with jsvm/cycle-theme")
 
 ;;;###autoload

--- a/init.el
+++ b/init.el
@@ -20,7 +20,7 @@
        ;;layout            ; auie,ctsrnm is the superior home row
 
        :completion
-       company           ; the ultimate code completion backend
+       (company +childframe)           ; the ultimate code completion backend
        ;;helm              ; the *other* search engine for love and life
        ;;ido               ; the other *other* search engine...
        ivy               ; a search engine for love and life
@@ -43,7 +43,7 @@
        ophints           ; highlight the region an operation acts on
        (popup +defaults)   ; tame sudden yet inevitable temporary windows
        ;;tabs              ; a tab bar for Emacs
-       ;;treemacs          ; a project drawer, like neotree but cooler
+       treemacs          ; a project drawer, like neotree but cooler
        ;;unicode           ; extended unicode support for various languages
        vc-gutter         ; vcs diff in the fringe
        vi-tilde-fringe   ; fringe tildes to mark beyond EOB
@@ -116,7 +116,7 @@
        ;;common-lisp       ; if you've seen one lisp, you've seen them all
        ;;coq               ; proofs-as-programs
        ;;crystal           ; ruby at the speed of c
-       ;;csharp            ; unity, .NET, and mono shenanigans
+       (csharp +lsp)            ; unity, .NET, and mono shenanigans
        ;;data              ; config/data formats
        ;;(dart +flutter)   ; paint ui and not much else
        ;;elixir            ; erlang done right

--- a/packages.el
+++ b/packages.el
@@ -49,6 +49,8 @@
 ;; ...Or *all* packages (NOT RECOMMENDED; will likely break things)
 ;(unpin! t)
 
+(disable-packages! evil-snipe)
+
 (package! transpose-frame)
 (package! terminal-here)
 

--- a/packages.el
+++ b/packages.el
@@ -54,6 +54,8 @@
 (package! transpose-frame)
 (package! terminal-here)
 
+(package! dotnet)
+
 ;; Polymode packages
 (when (package! polymode)
   (package! poly-markdown)

--- a/settings/appearance.el
+++ b/settings/appearance.el
@@ -1,14 +1,65 @@
 ;;; settings/appearance.el -*- lexical-binding: t; -*-
 
+(setq doom-font (font-spec :family "JetBrains Mono" :size 17)
+      doom-big-font (font-spec :family "Iosevka SS04" :size 36 :weight 'semibold)
+      doom-themes-treemacs-enable-variable-pitch nil
+      display-line-numbers-type nil)
+
+;; Ligatures support for JetBrains Mono
+;; * https://github.com/microsoft/cascadia-code/issues/153
+;; * https://gitlab.com/noaccOS/dotfiles/-/blob/master/.config/doom/config.el#L74
+(use-package! composite
+  :defer t
+  :init (defvar composition-ligature-table (make-char-table nil))
+  :hook ((prog-mode conf-mode markdown-mode help-mode nxml-mode)
+         . (lambda () (setq-local composition-function-table composition-ligature-table)))
+  :config
+  (when (version<= "27.0" emacs-version)
+    (let ((alist '((?! . "\\(?:!\\(?:==\\|[!=]\\)\\)")
+                   (?# . "\\(?:#\\(?:###?\\|_(\\|[!#(:=?[_{]\\)\\)")
+                   (?$ . "\\(?:\\$>\\)")
+                   (?& . "\\(?:&&&?\\)")
+                   (?* . "\\(?:\\*\\(?:\\*\\*\\|[/>]\\)\\)")
+                   (?+ . "\\(?:\\+\\(?:\\+\\+\\|[+>]\\)\\)")
+                   (?- . "\\(?:-\\(?:-[>-]\\|<<\\|>>\\|[<>|~-]\\)\\)")
+                   (?. . "\\(?:\\.\\(?:\\.[.<]\\|[.=?-]\\)\\)")
+
+                   ;; This one causes trouble somehow (https://www.reddit.com/r/emacs/comments/icem4s/emacs_271_freezes_when_using_font_ligatures)
+                   ;; (?/ . "\\(?:/\\(?:\\*\\*\\|//\\|==\\|[*/=>]\\)\\)")
+
+                   (?0 . ".\\(?:\\(x[a-fA-F0-9]\\).?\\)")
+                   (?: . "\\(?::\\(?:::\\|\\?>\\|[:<-?]\\)\\)")
+                   (?\; . "\\(?:;;\\)")
+                   (?< . "\\(?:<\\(?:!--\\|\\$>\\|\\*>\\|\\+>\\|-[<>|]\\|/>\\|<[<=-]\\|=\\(?:=>\\|[<=>|]\\)\\||\\(?:||::=\\|[>|]\\)\\|~[>~]\\|[$*+/:<=>|~-]\\)\\)")
+                   (?= . "\\(?:=\\(?:!=\\|/=\\|:=\\|=[=>]\\|>>\\|[=>]\\)\\)")
+                   (?> . "\\(?:>\\(?:=>\\|>[=>-]\\|[]:=-]\\)\\)")
+                   (?? . "\\(?:\\?[.:=?]\\)")
+                   (?\[ . "\\(?:\\[\\(?:||]\\|[<|]\\)\\)")
+                   (?\ . "\\(?:\\\\/?\\)")
+                   (?\] . "\\(?:]#\\)")
+                   (?^ . "\\(?:\\^=\\)")
+                   (?_ . "\\(?:_\\(?:|?_\\)\\)")
+                   (?{ . "\\(?:{|\\)")
+                   (?| . "\\(?:|\\(?:->\\|=>\\||\\(?:|>\\|[=>-]\\)\\|[]=>|}-]\\)\\)")
+                   (?~ . "\\(?:~\\(?:~>\\|[=>@~-]\\)\\)"))))
+      (dolist (char-regexp alist)
+        (set-char-table-range composition-function-table (car char-regexp)
+                              `([,(cdr char-regexp) 0 font-shape-gstring]))))
+    (set-char-table-parent composition-ligature-table composition-function-table)))
+
+;; Modeline settings
+(after! doom-modeline
+  (remove-hook 'doom-modeline-mode-hook #'size-indication-mode)
+  (setq doom-modeline-buffer-encoding nil
+        doom-modeline-vcs-max-length 24
+        doom-modeline-major-mode-icon t)
+  (map! :leader :desc "Modeline" "tm" #'hide-mode-line-mode))
+
+;; Change theme on the fly
 (use-package! cycle-theme
   :config
-  (setq doom-font (font-spec :family "Iosevka SS04" :size 18 :weight 'regular)
-        doom-big-font (font-spec :family "Iosevka SS04" :size 36 :weight 'semibold)
-        doom-theme (car jsvm/active-themes)
-        display-line-numbers-type nil)
+  (setq doom-theme (car jsvm/active-themes))
   (map! :leader
         :desc "Cycle theme" "tt" #'jsvm/cycle-theme))
-
-(map! :leader :desc "Modeline" "tm" #'hide-mode-line-mode)
 
 (provide 'appearance)

--- a/settings/editing.el
+++ b/settings/editing.el
@@ -13,15 +13,6 @@
     (add-to-list 'evil-mc-known-commands
                  `(,cmd . ((:default . evil-mc-execute-default-call))))))
 
-;; (use-package! company
-;;   :bind (:map company-active-map
-;;          ("<tab>" . company-complete-selection)
-;;          :map lsp-mode-map
-;;          ("<tab>" . company-indent-or-complete-common))
-;;   :custom
-;;   (company-idle-delay 0.0)
-;;   (company-minimum-prefix-length 1))
-
 (use-package! fill-line
   :config
   (map! :leader :prefix "i"

--- a/settings/ide.el
+++ b/settings/ide.el
@@ -1,0 +1,49 @@
+;;; settings/ide.el -*- lexical-binding: t; -*-
+
+;; LSP settings
+(after! lsp-mode
+  (map! :leader
+        :desc "Diagnostics" "c-" #'lsp-ui-flycheck-list
+        :desc "Imenu" "c," #'lsp-ui-imenu)
+  (setq lsp-headerline-breadcrumb-enable-diagnostics nil
+        lsp-headerline-breadcrumb-enable t
+        lsp-lens-enable t
+        lsp-ui-sideline-show-code-actions nil
+        lsp-ui-imenu--custom-mode-line-format ""
+        +lsp-company-backends '(company-capf company-yasnippet)))
+
+;; Completion settings
+(after! company
+  (map! :i "<tab>" #'company-indent-or-complete-common)
+  (map! :map company-active-map "<tab>" #'company-complete-common)
+  (setq company-idle-delay 0.0
+        company-minimum-prefix-length 1))
+
+;; .NET development
+(use-package! dotnet
+  :hook ((csharp-mode csproj-mode) . dotnet-mode)
+  :config
+  (map! :map dotnet-mode-map :leader :prefix ("c ." . ".NET")
+        (:prefix ("a" . "add")
+         :desc "Add package" "p" #'dotnet-add-package
+         :desc "Add reference" "r" #'dotnet-add-reference)
+        :desc "Build" "b" #'dotnet-build
+        :desc "Clean" "c" #'dotnet-clean
+        (:prefix ("g" . "goto")
+         :desc "Go to csproj" "c" #'dotnet-goto-csproj
+         :desc "Go to fsproj" "f" #'dotnet-goto-fsproj
+         :desc "Go to solution" "s" #'dotnet-goto-sln)
+        :desc "New" "n" #'dotnet-new
+        :desc "Publish" "p" #'dotnet-publish
+        :desc "Restore" "r" #'dotnet-restore
+        :desc "Run" "e" #'dotnet-run
+        :desc "Run with args" "C-e" #'dotnet-run-with-args
+        (:prefix ("s" . "solution")
+         :desc "Add project to solution" "a" #'dotnet-sln-add
+         :desc "List projects in solution" "l" #'dotnet-sln-list
+         :desc "New solution" "n" #'dotnet-sln-new
+         :desc "Remove project from solution" "r" #'dotnet-sln-remove)
+        :desc "Test" "t" #'dotnet-test)
+  (set-popup-rule! "^\\*dotnet" :select t :quit t :side 'bottom :size 0.3))
+
+(provide 'ide)

--- a/settings/window-mgmt.el
+++ b/settings/window-mgmt.el
@@ -19,4 +19,8 @@
   (map! "<C-s-return>" #'terminal-here-launch)
   (setq terminal-here-linux-terminal-command 'alacritty))
 
+;; Make better use of avy
+(after! avy
+  (map! :nvom "s" #'avy-goto-char-timer))
+
 (provide 'window-mgmt)

--- a/settings/window-mgmt.el
+++ b/settings/window-mgmt.el
@@ -13,11 +13,13 @@
 
 (map! :leader :desc "Find file in other window" "fo" #'find-file-other-window)
 
-;; Easy opening of terminal windows on my Linux machines
+;; Easy opening of terminal windows
 (use-package! terminal-here
   :config
-  (map! "<C-s-return>" #'terminal-here-launch)
-  (setq terminal-here-linux-terminal-command 'alacritty))
+  (map! (:when IS-LINUX "<C-s-return>" #'terminal-here-launch)
+        (:when IS-WINDOWS "<C-M-return>" #'terminal-here-launch))
+  (setq terminal-here-linux-terminal-command 'alacritty
+        terminal-here-windows-terminal-command (lambda (dir) (list "cmd.exe" "/C" "start" "wt.exe" "-d" dir))))
 
 ;; Make better use of avy
 (after! avy


### PR DESCRIPTION
This PR adds support for C#/.NET development and improves the visuals.

* Font changed to JetBrains Mono
* Company and LSP settings added to mimic IDEs
* Added support for terminal-here on Windows
* Tweaked theme settings a bit