### PR TITLE
Change cycle-theme to use load-theme instead of doom/reload-theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.dir-locals.el
+/custom.el

--- a/config.el
+++ b/config.el
@@ -8,6 +8,7 @@
 (add-load-path! "functions" "settings")
 
 ;; Load settings from files in subdirectory
+(use-package! bug-fixes)
 (use-package! appearance)
 (use-package! window-mgmt)
 (use-package! editing)

--- a/functions/cycle-theme.el
+++ b/functions/cycle-theme.el
@@ -9,8 +9,8 @@
   (interactive)
   (let ((new-theme (car (last jsvm/active-themes)))
         (old-themes (butlast jsvm/active-themes)))
-    (setq doom-theme new-theme)
     (setq jsvm/active-themes (cons new-theme old-themes))
-    (doom/reload-theme)))
+    (load-theme new-theme)
+    (message "Loaded theme: %s" new-theme)))
 
 (provide 'cycle-theme)

--- a/settings/appearance.el
+++ b/settings/appearance.el
@@ -36,7 +36,7 @@
 (use-package! modus-themes
   :init
   (setq modus-themes-bold-constructs t
-        modus-themes-slanted-constructs t
+        modus-themes-italic-constructs t
         modus-themes-mode-line '(borderless)
         modus-themes-paren-match 'intense-bold)
   (modus-themes-load-themes))

--- a/settings/bug-fixes.el
+++ b/settings/bug-fixes.el
@@ -1,0 +1,8 @@
+;;; bug-fixes.el -*- lexical-binding: t; -*-
+
+;; Fix a compatibility error with Emacs 29
+(when (version<= "29" emacs-version)
+  (after! elisp-refs
+    (defvar read-symbol-positions-list ())))
+
+(provide 'bug-fixes)


### PR DESCRIPTION
Fix `cycle-theme` not working by using `load-theme` directly instead of relying on internal logic of `doom/reload-theme`.
Because of this, a `custom.el` is generated when the themes are loaded — this has been gitignored.
Also fix an issue with a removed variable in Emacs 29.

This PR resolves #3 
