### PR TITLE
Add support for local overrides to settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.dir-locals.el
 /custom.el
+/local-config.el

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # My personal config for Doom Emacs
-
 These are my personal config files for [Doom Emacs](https://github.com/hlissner/doom-emacs).
 
 ## Prerequisites
+In addition to the Doom Emacs requirements, this config uses the font [Iosevka Nova](https://github.com/janusvm/iosevka-nova/) by default.
+However, this can be overridden via `local-config.el`, see below.
 
-In addition to the Doom Emacs requirements, this config uses the font [Iosevka Nova ](https://github.com/janusvm/iosevka-nova/).
+## Machine specific settings
+While I would ideally have just one config that gives a consistent result across different computers, the reality is that some things (such as font size settings) end up requiring a little bit of machine specific tinkering for me.
+
+This config allows for such settings by loading the (gitignored) file `local-config.el` after everything else, if it exists.
+The contents of such a file might for example look like:
+
+```elisp
+;;; $DOOMDIR/local-config.el -*- lexical-binding: t; -*-
+
+(setq doom-font (font-spec :family "Iosevka Nova" :size 32))
+```
+
+This would set the font size to 32 (rather than the default 18) for that specific machine only.
+I use this on a computer with a high density display, as UI scaling just seems to slightly blur everything.

--- a/config.el
+++ b/config.el
@@ -15,3 +15,6 @@
 (use-package! lisps)
 (use-package! writing)
 (use-package! ide)
+
+;; Load machine local settings, if available
+(load! "local-config.el" doom-private-dir t)

--- a/settings/appearance.el
+++ b/settings/appearance.el
@@ -1,7 +1,7 @@
 ;;; settings/appearance.el -*- lexical-binding: t; -*-
 
 ;; FONT SETTINGS ---------------------------------------------------------------
-(setq doom-font (font-spec :family "Iosevka Nova" :size 32)
+(setq doom-font (font-spec :family "Iosevka Nova" :size 18)
       doom-themes-treemacs-enable-variable-pitch nil
       display-line-numbers-type nil)
 


### PR DESCRIPTION
Add the option to override settings in the `settings/*.el` files with a gitignored file named `local-config.el`.
This file is loaded after the settings files, if it exists, and it's mainly meant as a way to resolve annoyances with font settings.

This PR resolves #2 